### PR TITLE
feat: move normal log messages to stdout instead of stderr

### DIFF
--- a/test/wait-for-it.py
+++ b/test/wait-for-it.py
@@ -10,14 +10,14 @@ import re
 
 MISSING_ARGS_TEXT = "Error: you need to provide a host and port to test."
 HELP_TEXT = "Usage:"  # Start of help text
-DIVIDE_LINE = '-'*71  # Output line of dashes
+DIVIDE_LINE = "-" * 71  # Output line of dashes
 
 
 class TestWaitForIt(unittest.TestCase):
     """
-        TestWaitForIt tests the wait-for-it.sh shell script.
-        The wait-for-it.sh script is assumed to be in the parent directory to
-        the test script.
+    TestWaitForIt tests the wait-for-it.sh shell script.
+    The wait-for-it.sh script is assumed to be in the parent directory to
+    the test script.
     """
 
     def execute(self, cmd):
@@ -26,11 +26,11 @@ class TestWaitForIt(unittest.TestCase):
         proc = Popen(args, stdout=PIPE, stderr=PIPE)
         out, err = proc.communicate()
         exitcode = proc.returncode
-        return exitcode, out.decode('utf-8'), err.decode('utf-8')
+        return exitcode, out.decode("utf-8"), err.decode("utf-8")
 
     def open_local_port(self, timeout=5):
         s = socket.socket()
-        s.bind(('', 0))
+        s.bind(("", 0))
         s.listen(timeout)
         return s, s.getsockname()[1]
 
@@ -39,17 +39,37 @@ class TestWaitForIt(unittest.TestCase):
         exitcode, out, err = self.execute(command)
 
         # Check stderr
-        msg = ("Failed check that STDERR:\n" +
-               DIVIDE_LINE + "\n" + err + "\n" + DIVIDE_LINE +
-               "\nmatches:\n" +
-               DIVIDE_LINE + "\n" + stderr_regex + "\n" + DIVIDE_LINE)
+        msg = (
+            "Failed check that STDERR:\n"
+            + DIVIDE_LINE
+            + "\n"
+            + err
+            + "\n"
+            + DIVIDE_LINE
+            + "\nmatches:\n"
+            + DIVIDE_LINE
+            + "\n"
+            + stderr_regex
+            + "\n"
+            + DIVIDE_LINE
+        )
         self.assertIsNotNone(re.match(stderr_regex, err, re.DOTALL), msg)
 
         # Check STDOUT
-        msg = ("Failed check that STDOUT:\n" +
-               DIVIDE_LINE + "\n" + out + "\n" + DIVIDE_LINE +
-               "\nmatches:\n" +
-               DIVIDE_LINE + "\n" + stdout_regex + "\n" + DIVIDE_LINE)
+        msg = (
+            "Failed check that STDOUT:\n"
+            + DIVIDE_LINE
+            + "\n"
+            + out
+            + "\n"
+            + DIVIDE_LINE
+            + "\nmatches:\n"
+            + DIVIDE_LINE
+            + "\n"
+            + stdout_regex
+            + "\n"
+            + DIVIDE_LINE
+        )
         self.assertIsNotNone(re.match(stdout_regex, out, re.DOTALL), msg)
 
         # Check exit code
@@ -62,121 +82,101 @@ class TestWaitForIt(unittest.TestCase):
 
     def test_no_args(self):
         """
-            Check that no aruments returns the missing args text and the
-            correct return code
+        Check that no aruments returns the missing args text and the
+        correct return code
         """
-        self.check_args(
-            "",
-            "^$",
-            MISSING_ARGS_TEXT,
-            False
-        )
+        self.check_args("", "^$", MISSING_ARGS_TEXT, False)
         # Return code should be 1 when called with no args
         exitcode, out, err = self.execute(self.wait_script)
-        self.assertEqual(exitcode, 	1)
+        self.assertEqual(exitcode, 1)
 
     def test_help(self):
-        """ Check that help text is printed with --help argument """
-        self.check_args(
-           "--help",
-           "",
-           HELP_TEXT,
-           False
-        )
+        """Check that help text is printed with --help argument"""
+        self.check_args("--help", "", HELP_TEXT, False)
 
     def test_no_port(self):
-        """ Check with missing port argument """
-        self.check_args(
-            "--host=localhost",
-            "",
-            MISSING_ARGS_TEXT,
-            False
-        )
+        """Check with missing port argument"""
+        self.check_args("--host=localhost", "", MISSING_ARGS_TEXT, False)
 
     def test_no_host(self):
-        """ Check with missing hostname argument """
-        self.check_args(
-            "--port=80",
-            "",
-            MISSING_ARGS_TEXT,
-            False
-        )
+        """Check with missing hostname argument"""
+        self.check_args("--port=80", "", MISSING_ARGS_TEXT, False)
 
     def test_host_port(self):
-        """ Check that --host and --port args work correctly """
+        """Check that --host and --port args work correctly"""
         soc, port = self.open_local_port()
         self.check_args(
             "--host=localhost --port={0} --timeout=1".format(port),
-            "",
             "wait-for-it.sh: waiting 1 seconds for localhost:{0}".format(port),
-            True
+            "",
+            True,
         )
         soc.close()
 
     def test_combined_host_port(self):
         """
-            Tests that wait-for-it.sh returns correctly after establishing a
-            connectionm using combined host and ports
+        Tests that wait-for-it.sh returns correctly after establishing a
+        connectionm using combined host and ports
         """
         soc, port = self.open_local_port()
         self.check_args(
             "localhost:{0} --timeout=1".format(port),
-            "",
             "wait-for-it.sh: waiting 1 seconds for localhost:{0}".format(port),
-            True
+            "",
+            True,
         )
         soc.close()
 
-
     def test_port_failure_with_timeout(self):
         """
-            Note exit status of 124 is exected, passed from the timeout command
+        Note exit status of 124 is exected, passed from the timeout command
         """
         self.check_args(
             "localhost:8929 --timeout=1",
             "",
             ".*timeout occurred after waiting 1 seconds for localhost:8929",
-            False
+            False,
         )
 
     def test_command_execution(self):
         """
-            Checks that a command executes correctly after a port test passes
+        Checks that a command executes correctly after a port test passes
         """
         soc, port = self.open_local_port()
         self.check_args(
-            "localhost:{0} -- echo \"CMD OUTPUT\"".format(port),
-            "CMD OUTPUT",
+            'localhost:{0} -- echo "CMD OUTPUT"'.format(port),
             ".*wait-for-it.sh: localhost:{0} is available after 0 seconds".format(port),
-            True
+            "",
+            True,
         )
         soc.close()
 
     def test_failed_command_execution(self):
         """
-            Check command failure. The command in question outputs STDERR and
-            an exit code of 2
+        Check command failure. The command in question outputs STDERR and
+        an exit code of 2
         """
         soc, port = self.open_local_port()
         self.check_args(
             "localhost:{0} -- ls not_real_file".format(port),
             "",
             ".*No such file or directory\n",
-            False
+            False,
         )
         soc.close()
 
     def test_command_after_connection_failure(self):
         """
-            Test that a command still runs even if a connection times out
-            and that the return code is correct for the comand being run
+        Test that a command still runs even if a connection times out
+        and that the return code is correct for the comand being run
         """
         self.check_args(
-            "localhost:8929 --timeout=1 -- echo \"CMD OUTPUT\"",
-            "CMD OUTPUT",
+            'localhost:8929 --timeout=1 -- echo "CMD OUTPUT"',
+            "",
             ".*timeout occurred after waiting 1 seconds for localhost:8929",
-            True
+            True,
         )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -4,6 +4,7 @@
 WAITFORIT_cmdname=${0##*/}
 
 echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+echoout() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@"; fi }
 
 usage()
 {
@@ -25,9 +26,9 @@ USAGE
 wait_for()
 {
     if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
-        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+        echoout "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
     else
-        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+        echoout "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
     fi
     WAITFORIT_start_ts=$(date +%s)
     while :
@@ -41,7 +42,7 @@ wait_for()
         fi
         if [[ $WAITFORIT_result -eq 0 ]]; then
             WAITFORIT_end_ts=$(date +%s)
-            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            echoout "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
             break
         fi
         sleep 1


### PR DESCRIPTION
General log messages were being logged at stderr instead of stdout, this caused unnecessary error logs in our systems raising alarms. Since everything is fine, moving such messages to stdout

## How to Test
1. Run the tests within the `test` directory by running `python wait-for-it.py`
2. Run all container tests using: `python container-runner.py` (if dependencies aren't installed, install using the `requirements.txt`)